### PR TITLE
Temporarily remove incomplete RRUFF collection

### DIFF
--- a/src/configs/config.spectra.yaml
+++ b/src/configs/config.spectra.yaml
@@ -10,11 +10,6 @@ SOLR_COLLECTIONS:
       name: plastic
       roles:
         - public
-    - description: RRUFF
-      license: TBD
-      name: rruf
-      roles:
-        - public
     - description: CHARISMA
       license: TBD
       name: charisma-public


### PR DESCRIPTION
## Motivation

The RRUFF collection is currently incomplete and may also be broken in other ways. Remove it from the spectra configuration temporarily so it is not advertised as an available public collection.

## Changes

- remove the RRUFF collection entry from `config.spectra.yaml`
- leave the remaining collections and default collection unchanged

## Validation

- confirmed there are no remaining RRUFF references under `src/configs/`
- `tests/test_solr_docs_config.py`: 5 passed; 2 could not run because FastAPI is not installed in the local Poetry environment